### PR TITLE
Fix I2C driver return type and add README

### DIFF
--- a/Arduino/examples/LVGL_Arduino/I2C_Driver.cpp
+++ b/Arduino/examples/LVGL_Arduino/I2C_Driver.cpp
@@ -4,21 +4,21 @@ void I2C_Init(void) {
   Wire.begin( I2C_SDA_PIN, I2C_SCL_PIN);                       
 }
 // 寄存器地址为 8 位的
-bool I2C_Read(uint8_t Driver_addr, uint8_t Reg_addr, uint8_t *Reg_data, uint32_t Length)
+esp_err_t I2C_Read(uint8_t Driver_addr, uint8_t Reg_addr, uint8_t *Reg_data, uint32_t Length)
 {
   Wire.beginTransmission(Driver_addr);
   Wire.write(Reg_addr); 
   if ( Wire.endTransmission(true)){
     printf("The I2C transmission fails. - I2C Read\r\n");
-    return -1;
+    return ESP_FAIL;
   }
   Wire.requestFrom(Driver_addr, Length);
   for (int i = 0; i < Length; i++) {
     *Reg_data++ = Wire.read();
   }
-  return 0;
+  return ESP_OK;
 }
-bool I2C_Write(uint8_t Driver_addr, uint8_t Reg_addr, const uint8_t *Reg_data, uint32_t Length)
+esp_err_t I2C_Write(uint8_t Driver_addr, uint8_t Reg_addr, const uint8_t *Reg_data, uint32_t Length)
 {
   Wire.beginTransmission(Driver_addr);
   Wire.write(Reg_addr);       
@@ -28,7 +28,7 @@ bool I2C_Write(uint8_t Driver_addr, uint8_t Reg_addr, const uint8_t *Reg_data, u
   if ( Wire.endTransmission(true))
   {
     printf("The I2C transmission fails. - I2C Write\r\n");
-    return -1;
+    return ESP_FAIL;
   }
-  return 0;
+  return ESP_OK;
 }

--- a/Arduino/examples/LVGL_Arduino/I2C_Driver.h
+++ b/Arduino/examples/LVGL_Arduino/I2C_Driver.h
@@ -1,10 +1,11 @@
 #pragma once
-#include <Wire.h> 
+#include <Wire.h>
+#include <esp_err.h>
 
 #define I2C_SCL_PIN       7
 #define I2C_SDA_PIN       15
 
 
 void I2C_Init(void);
-bool I2C_Read(uint8_t Driver_addr, uint8_t Reg_addr, uint8_t *Reg_data, uint32_t Length);
-bool I2C_Write(uint8_t Driver_addr, uint8_t Reg_addr, const uint8_t *Reg_data, uint32_t Length);
+esp_err_t I2C_Read(uint8_t Driver_addr, uint8_t Reg_addr, uint8_t *Reg_data, uint32_t Length);
+esp_err_t I2C_Write(uint8_t Driver_addr, uint8_t Reg_addr, const uint8_t *Reg_data, uint32_t Length);

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# ESP32 LCD Demo
+
+This repository provides demo code and firmware for the ESP32-S3 Touch LCD 2.8" board. It contains Arduino and ESP-IDF examples as well as a pre-built firmware image.
+
+## Repository Layout
+
+- **Arduino/** – Arduino sketches and required libraries
+  - `examples/` – ready-to-build Arduino example
+  - `libraries/` – LVGL and other libraries used by the example
+- **ESP-IDF/** – ESP-IDF example project which can be opened in VS Code
+- **Firmware/** – pre-built firmware image (`.bin`) that can be flashed via `flash_download_tool_3.9.5` at address `0x00`
+
+## Building the Examples
+
+### Arduino
+1. Open `Arduino/examples/LVGL_Arduino` in the Arduino IDE.
+2. Install the libraries located under `Arduino/libraries` if required.
+3. Compile and upload the sketch to your board.
+
+### ESP‑IDF
+1. Open the folder `ESP-IDF/ESP32-S3-Touch-LCD-2.8C-Test` in VS Code with the ESP‑IDF extension installed.
+2. Run `idf.py -p PORT build flash monitor` to build and flash the firmware.
+
+If compilation fails after a successful build, re-extract the project and try again.
+
+## License
+
+The code in this repository is licensed under its respective source files. Refer to the headers inside the project for more details.


### PR DESCRIPTION
## Summary
- convert existing readme text into a proper `README.md`
- fix the `I2C_Driver` functions to return `esp_err_t`

## Testing
- `python3 -m py_compile ESP-IDF/ESP32-S3-Touch-LCD-2.8C-Test/pytest_rgb_panel_lvgl.py`
- *(fails: `pytest` not installed)*